### PR TITLE
Make sure that _mocha is executed via node

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "contextify": "latest"
   },
   "scripts": {
-    "test": "./node_modules/.bin/_mocha --reporter spec",
+    "test": "node ./node_modules/.bin/_mocha --reporter spec",
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "engines": { "node" : ">= 0.10" },


### PR DESCRIPTION
Since mochajs/mocha@1430c2b, .../.bin/_mocha no longer starts with
  #!/usr/bin/env node
so just executing it will result in the attempt to run it as a shell script