### PR TITLE
Escaping backticks in validator.escape()

### DIFF
--- a/test/sanitizers.js
+++ b/test/sanitizers.js
@@ -116,6 +116,7 @@ describe('Sanitizers', function () {
           , expect: {
                 '<script> alert("xss&fun"); </script>': '&lt;script&gt; alert(&quot;xss&amp;fun&quot;); &lt;&#x2F;script&gt;'
               , "<script> alert('xss&fun'); </script>": '&lt;script&gt; alert(&#x27;xss&amp;fun&#x27;); &lt;&#x2F;script&gt;'
+              , 'Backtick: `': 'Backtick: &#96;'
             }
         });
     });

--- a/validator.js
+++ b/validator.js
@@ -581,7 +581,8 @@
             .replace(/'/g, '&#x27;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
-            .replace(/\//g, '&#x2F;'));
+            .replace(/\//g, '&#x2F;')
+            .replace(/\`/g, '&#96;'));
     };
 
     validator.stripLow = function (str, keep_new_lines) {


### PR DESCRIPTION
Without proper escaping, this could lead to XSS in IE9.
References:
- https://html5sec.org/#102
- https://html5sec.org/#108
- https://html5sec.org/#133

The same rule is followed by lodash, as seen here: https://github.com/lodash/lodash/blob/master/lodash.src.js#L9917