### PR TITLE
Remove unneeded files from bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "Makefile",
+    "package.json"
   ]
 }


### PR DESCRIPTION
`Makefile` and `package.json` files are useless within bower package thus they should be removed from there.