### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "engines": { "node" : ">= 0.10" },
-  "licenses": [
-    { "type": "MIT"
-    , "url": "http://github.com/chriso/validator.js/raw/master/LICENSE" }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/