### PR TITLE
Fix #435: Convert returned comparison in isBefore() to a boolean.

### DIFF
--- a/test/validators.js
+++ b/test/validators.js
@@ -876,6 +876,11 @@ describe('Validators', function () {
         test({ validator: 'isAfter',
             valid: [ '2100-08-04', new Date(Date.now() + 86400000) ],
             invalid: [ '2010-07-02', new Date(0) ] });
+        test({ validator: 'isAfter', args: ['2011-08-03'],
+            valid: [ '2015-09-17' ],
+            invalid: [ 'invalid date' ] });
+        test({ validator: 'isAfter', args: ['invalid date'],
+            invalid: [ 'invalid date', '2015-09-17' ] });
     });
 
     it('should validate dates against an end date', function () {
@@ -888,6 +893,11 @@ describe('Validators', function () {
         test({ validator: 'isBefore',
             valid: [ '2000-08-04', new Date(0), new Date(Date.now() - 86400000) ],
             invalid: [ '2100-07-02', new Date(2017, 10, 10) ] });
+        test({ validator: 'isBefore', args: ['2011-08-03'],
+            valid: [ '1999-12-31' ],
+            invalid: [ 'invalid date' ] });
+        test({ validator: 'isBefore', args: ['invalid date'],
+            invalid: [ 'invalid date', '1999-12-31' ] });
     });
 
     it('should validate that integer strings are divisible by a number', function () {

--- a/validator.js
+++ b/validator.js
@@ -480,7 +480,7 @@
     validator.isBefore = function (str, date) {
         var comparison = validator.toDate(date || new Date())
           , original = validator.toDate(str);
-        return original && comparison && original < comparison;
+        return !!(original && comparison && original < comparison);
     };
 
     validator.isIn = function (str, options) {


### PR DESCRIPTION
Fixed a bug where `isBefore()` returns `null` if either of the arguments are invalid dates.

Turns out that `isAfter()` was already returning a boolean, so I just emulated that return style. Also added a few tests to show that invalid dates will return false in `isAfter()` and `isBefore()`.