### PR TITLE
Fix tests in node v4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - "4.0"
+  - "4.1"
 after_script:
   - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ validator.isWhitespace('foo bar');
 
 ### Tests
 
+Tests require node v4.0+.
+
 - `make test` - run the test suite.
 - `make test V=1` - run the test suite with added verbosity.
 - `make test TEST=pattern` - run tests that match a pattern.

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "istanbul": "latest",
     "jshint": "latest",
     "uglify-js": "latest",
-    "coveralls": "latest",
-    "contextify": "latest"
+    "coveralls": "latest"
   },
   "scripts": {
     "test": "node ./node_modules/.bin/_mocha --reporter spec",

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,9 +1,9 @@
 var validator = require('../validator')
   , format = require('util').format
-  , contextify = require('contextify')
   , assert = require('assert')
   , path = require('path')
-  , fs = require('fs');
+  , fs = require('fs')
+  , vm = require('vm');
 
 var validator_js = fs.readFileSync(path.join(__dirname, '../validator.js')).toString();
 
@@ -1187,17 +1187,16 @@ describe('Validators', function () {
             }
         };
         window.define.amd = true;
-        var sandbox = contextify(window);
-        sandbox.run(validator_js);
-        sandbox.dispose();
+
+        var sandbox = vm.createContext(window);
+        vm.runInContext(validator_js, sandbox);
         assert.equal(window.validator.trim('  foobar '), 'foobar');
     });
 
     it('should bind validator to the window if no module loaders are available', function () {
         var window = {};
-        var sandbox = contextify(window);
-        sandbox.run(validator_js);
-        sandbox.dispose();
+        var sandbox = vm.createContext(window);
+        vm.runInContext(validator_js, sandbox);
         assert.equal(window.validator.trim('  foobar '), 'foobar');
     });
 


### PR DESCRIPTION
[contextify](https://github.com/brianmcd/contextify) doesn't work with node v4+ yet: https://github.com/brianmcd/contextify/issues/180

This PR removes it in favour of the builtin `vm` module. The `vm` module doesn't do what we need it to do in older versions of node and there doesn't appear to be a way to conditionally install `contextify` based on the version of node that's installed, so not sure what the best solution is here. Either wait until contextify is fixed, or wait until everyone upgrades to node 4+.