### PR TITLE
Make `isLength() / isByteLength()` accept an options object `{min, max}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Make `isLength() / isByteLength()` also accept `{min, max}` as options object.
+  ([#474](https://github.com/chriso/validator.js/issues/474))
+
 #### 4.5.0
 
 - Add validation for Indian mobile phone numbers

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ bower install validator-js
 - **isBase64(str)** - check if a string is base64 encoded.
 - **isBefore(str [, date])** - check if the string is a date that's before the specified date.
 - **isBoolean(str)** - check if a string is a boolean.
-- **isByteLength(str, min [, max])** - check if the string's length (in bytes) falls in a range.
+- **isByteLength(str, options)** - check if the string's length (in bytes) falls in a range.`options` is an object which defaults to `{min:0, max: undefined}`.
 - **isCreditCard(str)** - check if the string is a credit card.
 - **isCurrency(str, options)** - check if the string is a valid currency amount. `options` is an object which defaults to `{symbol: '$', require_symbol: false, allow_space_after_symbol: false, symbol_after_digits: false, allow_negatives: true, parens_for_negatives: false, negative_sign_before_digits: false, negative_sign_after_digits: false, allow_negative_sign_placeholder: false, thousands_separator: ',', decimal_separator: '.', allow_space_after_digits: false }`.
 - **isDate(str)** - check if the string is a date.
@@ -62,7 +62,7 @@ $ bower install validator-js
 - **isIn(str, values)** - check if the string is in a array of allowed values.
 - **isInt(str [, options])** - check if the string is an integer. `options` is an object which can contain the keys `min` and/or `max` to check the integer is within boundaries (e.g. `{ min: 10, max: 99 }`).
 - **isJSON(str)** - check if the string is valid JSON (note: uses JSON.parse).
-- **isLength(str, min [, max])** - check if the string's length falls in a range. Note: this function takes into account surrogate pairs.
+- **isLength(str, options)** - check if the string's length falls in a range. `options` is an object which defaults to `{min:0, max: undefined}`. Note: this function takes into account surrogate pairs.
 - **isLowercase(str)** - check if the string is lowercase.
 - **isMACAddress(str)** - check if the string is a MAC address.
 - **isMobilePhone(str, locale)** - check if the string is a mobile phone number, (locale is one of `['zh-CN', 'zh-TW', 'en-ZA', 'en-AU', 'en-HK', 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ', 'en-IN']`).

--- a/test/validators.js
+++ b/test/validators.js
@@ -772,15 +772,32 @@ describe('Validators', function () {
             invalid: ['acb'] });
     });
 
-    it('should validate strings by length', function () {
+    it('should validate strings by length (deprecated api)', function () {
         test({ validator: 'isLength', args: [2], valid: ['abc', 'de', 'abcd'], invalid: [ '', 'a' ] });
         test({ validator: 'isLength', args: [2, 3], valid: ['abc', 'de'], invalid: [ '', 'a', 'abcd' ] });
         test({ validator: 'isLength', args: [2, 3], valid: ['干𩸽', '𠮷野家'], invalid: [ '', '𠀋', '千竈通り' ] });
+        test({ validator: 'isLength', args: [0, 0], valid: [''], invalid: ['a', 'ab'] });
+    });
+
+    it('should validate strings by byte length (deprecated api)', function () {
+        test({ validator: 'isByteLength', args: [2], valid: ['abc', 'de', 'abcd', 'ｇｍａｉｌ'], invalid: [ '', 'a' ] });
+        test({ validator: 'isByteLength', args: [2, 3], valid: ['abc', 'de', 'ｇ'], invalid: [ '', 'a', 'abcd', 'ｇｍ' ] });
+        test({ validator: 'isByteLength', args: [0, 0], valid: [''], invalid: ['ｇ', 'a'] });
+    });
+
+    it('should validate strings by length', function () {
+        test({ validator: 'isLength', args: [{min: 2}], valid: ['abc', 'de', 'abcd'], invalid: ['', 'a'] });
+        test({ validator: 'isLength', args: [{min: 2, max: 3}], valid: ['abc', 'de'], invalid: ['', 'a', 'abcd'] });
+        test({ validator: 'isLength', args: [{min: 2, max: 3}], valid: ['干𩸽', '𠮷野家'], invalid: [ '', '𠀋', '千竈通り' ] });
+        test({ validator: 'isLength', args: [{max: 3}], valid: ['abc', 'de', 'a', ''], invalid: ['abcd'] });
+        test({ validator: 'isLength', args: [{max: 0}], valid: [''], invalid: ['a', 'ab'] });
     });
 
     it('should validate strings by byte length', function () {
-        test({ validator: 'isByteLength', args: [2], valid: ['abc', 'de', 'abcd', 'ｇｍａｉｌ'], invalid: [ '', 'a' ] });
-        test({ validator: 'isByteLength', args: [2, 3], valid: ['abc', 'de', 'ｇ'], invalid: [ '', 'a', 'abcd', 'ｇｍ' ] });
+        test({ validator: 'isByteLength', args: [{min: 2}], valid: ['abc', 'de', 'abcd', 'ｇｍａｉｌ'], invalid: ['', 'a'] });
+        test({ validator: 'isByteLength', args: [{min: 2, max: 3}], valid: ['abc', 'de', 'ｇ'], invalid: ['', 'a', 'abcd', 'ｇｍ'] });
+        test({ validator: 'isByteLength', args: [{max: 3}], valid: ['abc', 'de', 'ｇ', 'a', ''], invalid: ['abcd', 'ｇｍ'] });
+        test({ validator: 'isByteLength', args: [{max: 0}], valid: [''], invalid: ['ｇ', 'a'] });
     });
 
     it('should validate UUIDs', function () {

--- a/validator.js
+++ b/validator.js
@@ -197,8 +197,8 @@
             user = user.replace(/\./g, '').toLowerCase();
         }
 
-        if (!validator.isByteLength(user, 0, 64) ||
-                !validator.isByteLength(domain, 0, 256)) {
+        if (!validator.isByteLength(user, {max: 64}) ||
+                !validator.isByteLength(domain, {max: 256})) {
             return false;
         }
 
@@ -467,13 +467,28 @@
         return str.length === 0;
     };
 
-    validator.isLength = function (str, min, max) {
+    validator.isLength = function (str, options) {
+        var min, max;
+        if (typeof(options) === 'object') {
+            min = options.min || 0;
+            max = options.max;
+        } else { // backwards compatibility: isLength(str, min [, max])
+            min = arguments[1];
+            max = arguments[2];
+        }
         var surrogatePairs = str.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || [];
         var len = str.length - surrogatePairs.length;
         return len >= min && (typeof max === 'undefined' || len <= max);
     };
-
-    validator.isByteLength = function (str, min, max) {
+    validator.isByteLength = function (str, options) {
+        var min, max;
+        if (typeof(options) === 'object') {
+            min = options.min || 0;
+            max = options.max;
+        } else { // backwards compatibility: isByteLength(str, min [, max])
+            min = arguments[1];
+            max = arguments[2];
+        }
         var len = encodeURI(str).split(/%..|./).length - 1;
         return len >= min && (typeof max === 'undefined' || len <= max);
     };


### PR DESCRIPTION
Usage:
- `isLength(str, {min: 4, max: 6})`
- `isLength(str, {min: 4})`
- `isLength(str, {max: 10})`

Because:
- More consitent with `isInt({min:0, max:0})` and `isFloat({min:0, max: 0})`
- More consitent with `isCurrency(str, options)`
- Avoids confusions like #465
- Allows `isLength({max: 10})`
- Backwards compatible.
- Better readability:
   - `isLength(str, 4)` reads like `(str.length == 4)`, but actually is `(str.length >= 4)`
   - Before: `isLength(str, 4, 10)` what do 4 and 10 mean?
   - After: `isLength(str, {min: 4, max:10})`

closes #474