### PR TITLE
Handle case where object does not have a toString function.

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -126,8 +126,12 @@
     };
 
     validator.toString = function (input) {
-        if (typeof input === 'object' && input !== null && input.toString) {
-            input = input.toString();
+        if (typeof input === 'object' && input !== null) {
+            if (input.toString) {
+                input = input.toString();
+            } else {
+                input = '[Object object]';
+            }
         } else if (input === null || typeof input === 'undefined' || (isNaN(input) && !input.length)) {
             input = '';
         }


### PR DESCRIPTION
- If no toString function is defined, just use '[Object object]' as the result.
- This happens if the object was created with Object.create(null).

This addresses issue #484 