### PR TITLE
Default to en-US if locale is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #### HEAD
 
+- Default to en-US if locale is not found in `isAlpha()` and `isAlphanumeric()`
+  ([#488](https://github.com/chriso/validator.js/pull/488))
 - Use [node-depd](https://github.com/dougwilson/nodejs-depd) to print deprecation notices
   ([#487](https://github.com/chriso/validator.js/issues/487))
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -609,6 +609,24 @@ describe('Validators', function () {
         });
     });
 
+    it('should default to en-US on alphanumeric strings', function () {
+        test({
+            validator: 'isAlphanumeric'
+          , args: ['en-GB']
+          , valid: [
+                'abc123'
+              , 'ABC11'
+            ]
+          , invalid: [
+              'abc '
+            , 'foo!!'
+            , 'ÄBC'
+            , 'FÜübar'
+            , 'Jön'
+            ]
+        });
+    });
+
     it('should validate numeric strings', function () {
         test({
             validator: 'isNumeric'

--- a/validator.js
+++ b/validator.js
@@ -449,13 +449,13 @@
     };
 
     validator.isAlpha = function (str, locale) {
-        locale = locale || 'en-US';
-        return alpha[locale].test(str);
+        var regex = alpha[locale] || alpha['en-US'];
+        return regex.test(str);
     };
 
     validator.isAlphanumeric = function (str, locale) {
-        locale = locale || 'en-US';
-        return alphanumeric[locale].test(str);
+        var regex = alphanumeric[locale] || alphanumeric['en-US'];
+        return regex.test(str);
     };
 
     validator.isNumeric = function (str) {


### PR DESCRIPTION
Fixed the `isAlpha` and `isAlphanumeric` methods to support locales that are not found by defaulting to `en-US`.

- Old code: If `locale` is `en-GB` for example, `alpha[locale]` will be `undefined` and will output an error `Cannot read property 'test' of undefined`.

```
validator.isAlpha = function (str, locale) {
        locale = locale || 'en-US';
        return alpha[locale].test(str);
};
```

- New code: If `alpha[locale]` is undefined, `alpha['en-US']` will be used instead.
```
    validator.isAlpha = function (str, locale) {
        var regex = alpha[locale] || alpha['en-US'];
        return regex.test(str);
    };
```