### PR TITLE
Allow prepended zeroes in toInt()

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Passing anything other than a string is an error.
 - **isISIN(str)** - check if the string is an [ISIN][ISIN] (stock/security identifier).
 - **isISO8601(str)** - check if the string is a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date.
 - **isIn(str, values)** - check if the string is in a array of allowed values.
-- **isInt(str [, options])** - check if the string is an integer. `options` is an object which can contain the keys `min` and/or `max` to check the integer is within boundaries (e.g. `{ min: 10, max: 99 }`).
+- **isInt(str [, options])** - check if the string is an integer. `options` is an object which can contain the keys `min` and/or `max` to check the integer is within boundaries (e.g. `{ min: 10, max: 99 }`). `options` can also contain the key `allow_leading_zeroes`, which when set to true will accept integer values with leading zeroes (e.g. `{ allow_leading_zeroes: true }`).
 - **isJSON(str)** - check if the string is valid JSON (note: uses JSON.parse).
 - **isLength(str, options)** - check if the string's length falls in a range. `options` is an object which defaults to `{min:0, max: undefined}`. Note: this function takes into account surrogate pairs.
 - **isLowercase(str)** - check if the string is lowercase.

--- a/src/lib/isAscii.js
+++ b/src/lib/isAscii.js
@@ -1,6 +1,8 @@
 import assertString from './util/assertString';
 
+/* eslint-disable no-control-regex */
 const ascii = /^[\x00-\x7F]+$/;
+/* eslint-enable no-control-regex */
 
 export default function isAscii(str) {
   assertString(str);

--- a/src/lib/isEmail.js
+++ b/src/lib/isEmail.js
@@ -11,12 +11,14 @@ const default_email_options = {
 };
 
 /* eslint-disable max-len */
+/* eslint-disable no-control-regex */
 const displayName = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\.\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\.\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF\s]*<(.+)>$/i;
 const emailUserPart = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~]+$/i;
 const quotedEmailUser = /^([\s\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e]|(\\[\x01-\x09\x0b\x0c\x0d-\x7f]))*$/i;
 const emailUserUtf8Part = /^[a-z\d!#\$%&'\*\+\-\/=\?\^_`{\|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+$/i;
 const quotedEmailUserUtf8 = /^([\s\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|(\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*$/i;
 /* eslint-enable max-len */
+/* eslint-enable no-control-regex */
 
 export default function isEmail(str, options) {
   assertString(str);

--- a/src/lib/isInt.js
+++ b/src/lib/isInt.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const int = /^(?:[-+]?(?:0|[1-9][0-9]*))$/;
+const int = /^[-+]?[0-9]+$/;
 
 export default function isInt(str, options) {
   assertString(str);

--- a/src/lib/isInt.js
+++ b/src/lib/isInt.js
@@ -1,10 +1,23 @@
 import assertString from './util/assertString';
 
-const int = /^[-+]?[0-9]+$/;
+const int = /^(?:[-+]?(?:0|[1-9][0-9]*))$/;
+const intLeadingZeroes = /^[-+]?[0-9]+$/;
 
 export default function isInt(str, options) {
   assertString(str);
   options = options || {};
-  return int.test(str) && (!options.hasOwnProperty('min') ||
-    str >= options.min) && (!options.hasOwnProperty('max') || str <= options.max);
+
+  // Get the regex to use for testing, based on whether
+  // leading zeroes are allowed or not.
+  let regex = (
+    options.hasOwnProperty('allow_leading_zeroes') && options.allow_leading_zeroes ?
+    intLeadingZeroes :
+    int
+  );
+
+  // Check min/max
+  let minCheckPassed = (!options.hasOwnProperty('min') || str >= options.min);
+  let maxCheckPassed = (!options.hasOwnProperty('max') || str <= options.max);
+
+  return regex.test(str) && minCheckPassed && maxCheckPassed;
 }

--- a/src/lib/isMultibyte.js
+++ b/src/lib/isMultibyte.js
@@ -1,6 +1,8 @@
 import assertString from './util/assertString';
 
+/* eslint-disable no-control-regex */
 const multibyte = /[^\x00-\x7F]/;
+/* eslint-enable no-control-regex */
 
 export default function isMultibyte(str) {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -890,11 +890,11 @@ describe('Validators', function () {
         '123',
         '-0',
         '+1',
-      ],
-      invalid: [
         '01',
         '-01',
         '000',
+      ],
+      invalid: [
         '100e10',
         '123.123',
         '   ',

--- a/test/validators.js
+++ b/test/validators.js
@@ -890,9 +890,32 @@ describe('Validators', function () {
         '123',
         '-0',
         '+1',
+      ],
+      invalid: [
         '01',
         '-01',
         '000',
+        '100e10',
+        '123.123',
+        '   ',
+        '',
+      ],
+    });
+    test({
+      validator: 'isInt',
+      args: [{ allow_leading_zeroes: true }],
+      valid: [
+        '13',
+        '123',
+        '0',
+        '123',
+        '-0',
+        '+1',
+        '01',
+        '-01',
+        '000',
+        '-000',
+        '+000',
       ],
       invalid: [
         '100e10',


### PR DESCRIPTION
I updated the `isInt()` method so it treats numeric strings with prepended zeroes as valid integers. Since the `parseInt()` function in JavaScript properly parses zero-prepended strings, it would make sense that the `isInt()` function would support it as well.

I'm curious if it might be better for the `isInt()` function to check for integer values by using `parseInt()` and checking whether it returns NaN. That way it's ensured that the `isInt()` method will always validate integers that can properly be parsed by `toInt()` (or rather, by `parseInt()` by proxy).