### PR TITLE
Fix subset importing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import validator from 'validator';
 Or, import only a subset of the library:
 
 ```javascript
-import isEmail from 'validator/lib/isEmail';
+import { isEmail } from 'validator/lib/isEmail';
 ```
 
 ### Client-side usage


### PR DESCRIPTION
To import a subset curly braces are required in ES6.