### PR TITLE
Fix "isUrl" max length

### DIFF
--- a/src/lib/isURL.js
+++ b/src/lib/isURL.js
@@ -33,7 +33,7 @@ function checkHost(host, matches) {
 
 export default function isURL(url, options) {
   assertString(url);
-  if (!url || url.length >= 2083 || /[\s<>]/.test(url)) {
+  if (!url || url.length > 2083 || /[\s<>]/.test(url)) {
     return false;
   }
   if (url.indexOf('mailto:') === 0) {


### PR DESCRIPTION
I think that 2083 characters URL is valid.
https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2,083-characters-in-internet-explorer