### PR TITLE
Improve require() time to <10ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "assert"
   ],
   "author": "Chris O'Hara <cohara87@gmail.com>",
-  "main": "index.js",
+  "main": "validator.js",
   "bugs": {
     "url": "http://github.com/chriso/validator.js/issues"
   },
@@ -35,6 +35,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-es2015-rollup": "^1.2.0",
+    "clear-require": "^2.0.0",
     "coveralls": "^2.11.9",
     "eslint": "^3.8.1",
     "eslint-config-airbnb-base": "^9.0.0",

--- a/test/startup.js
+++ b/test/startup.js
@@ -1,13 +1,14 @@
 var assert = require('assert');
 var clearRequire = require('clear-require');
+let validator = '';
 
-describe ('Startup', function () {
-  it ('should take <10ms to load', function () {
-    clearRequire.all()
+describe('Startup', function() {
+  it('should take <10ms to load', function() {
+    clearRequire.all();
     const start = process.hrtime();
-    let validator = require('../validator');
+    validator = require('../validator');
     const end = process.hrtime(start);
     const time = (end[0] * 1000) + (end[1] / 1000000);
-    assert(time<10);
+    assert(time < 10);
   });
 });

--- a/test/startup.js
+++ b/test/startup.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+var clearRequire = require('clear-require');
+
+describe ('Startup', function () {
+  it ('should take <10ms to load', function () {
+    clearRequire.all()
+    const start = process.hrtime();
+    let validator = require('../validator');
+    const end = process.hrtime(start);
+    const time = (end[0] * 1000) + (end[1] / 1000000);
+    assert(time<10);
+  });
+});

--- a/test/startup.js
+++ b/test/startup.js
@@ -1,11 +1,14 @@
 var assert = require('assert');
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 var clearRequire = require('clear-require');
+
 let validator = '';
 
-describe('Startup', function() {
-  it('should take <10ms to load', function() {
+describe('Startup', function () {
+  it('should take <10ms to load', function () {
     clearRequire.all();
     const start = process.hrtime();
+    // eslint-disable-line global-require
     validator = require('../validator');
     const end = process.hrtime(start);
     const time = (end[0] * 1000) + (end[1] / 1000000);

--- a/test/startup.js
+++ b/test/startup.js
@@ -2,14 +2,12 @@ var assert = require('assert');
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 var clearRequire = require('clear-require');
 
-let validator = '';
-
 describe('Startup', function () {
   it('should take <10ms to load', function () {
     clearRequire.all();
     const start = process.hrtime();
-    // eslint-disable-line global-require
-    validator = require('../validator');
+    // eslint-disable-next-line global-require
+    let validator = require('../validator'); // eslint-disable-line no-unused-vars
     const end = process.hrtime(start);
     const time = (end[0] * 1000) + (end[1] / 1000000);
     assert(time < 10);


### PR DESCRIPTION
I'm trying to speed up the load time of a package called Sequelize your package is one of it's dependencies. It is taking 50ms on my machine to require your package this is because it takes 1ms per require from index.js, you already had a minified version of the project so I've simply updated the package.json to expose this file instead. I also added a test to make sure load times stay below <10ms