### PR TITLE
Export isPostalCode locales

### DIFF
--- a/lib/isPostalCode.js
+++ b/lib/isPostalCode.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.locales = undefined;
 
 exports.default = function (str, locale) {
   (0, _assertString2.default)(str);
@@ -71,4 +72,4 @@ var patterns = {
   ZM: fiveDigit
 };
 
-module.exports = exports['default'];
+var locales = exports.locales = Object.keys(patterns);

--- a/src/lib/isPostalCode.js
+++ b/src/lib/isPostalCode.js
@@ -43,6 +43,8 @@ const patterns = {
   ZM: fiveDigit,
 };
 
+export const locales = Object.keys(patterns);
+
 export default function (str, locale) {
   assertString(str);
   if (locale in patterns) {

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var validator = require('../index');
+var isPostalCodeLocales = require('../lib/isPostalCode').locales;
 
 describe('Exports', function () {
   it('should export validators', function () {
@@ -17,5 +18,9 @@ describe('Exports', function () {
     assert.equal(validator.version, require('../package.json').version,
       'Version number mismatch in "package.json" vs. "validator.js"');
     /* eslint-enable global-require */
+  });
+
+  it('should export isPostalCode\'s supported locales', function () {
+    assert.ok(isPostalCodeLocales instanceof Array);
   });
 });


### PR DESCRIPTION
This PR exports the list of supported locales that `isPostalCode` supports so that callers can prevent the validation function from throwing by not calling it if the locale isn't supported. 

I created this PR as a proof-of-concept to address https://github.com/chriso/validator.js/issues/719 but I'm not 100% sure this is the best approach. 