### PR TITLE
Fixed ES 6 import syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ validator.isEmail('foo@bar.com'); //=> true
 #### ES6
 
 ```javascript
-import validator from 'validator';
+import * as validator from 'validator';
 ```
 
 Or, import only a subset of the library:
 
 ```javascript
-import isEmail from 'validator/lib/isEmail';
+import { isEmail } from 'validator/lib/isEmail';
 ```
 
 ### Client-side usage


### PR DESCRIPTION
The syntax of ES6 imports in the readme file is not correct.

For reference, see: https://developer.mozilla.org/nl/docs/Web/JavaScript/Reference/Statements/import#Syntax