### PR TITLE
isPostalCode validation for AU locale was checking for six digits instead of four

### DIFF
--- a/src/lib/isPostalCode.js
+++ b/src/lib/isPostalCode.js
@@ -8,7 +8,7 @@ const sixDigit = /^\d{6}$/;
 
 const patterns = {
   AT: fourDigit,
-  AU: sixDigit,
+  AU: fourDigit,
   BE: fourDigit,
   CA: /^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][\s\-]?\d[ABCEGHJ-NPRSTV-Z]\d$/i,
   CH: fourDigit,

--- a/test/validators.js
+++ b/test/validators.js
@@ -4933,6 +4933,16 @@ describe('Validators', function () {
   it('should validate postal code', function () {
     const fixtures = [
       {
+        locale: 'AU',
+        valid: [
+          '4000',
+          '2620',
+          '3000',
+          '2017',
+          '0800',
+        ],
+      },
+      {
         locale: 'CA',
         valid: [
           'L4T 0A5',


### PR DESCRIPTION
isPostalCode validation for AU locale was checking for six digits, but Australian Postal Codes are 4 digits. Added a unit test for the use case also