### PR TITLE
Fix failing test for isBefore().

### DIFF
--- a/test/validators.js
+++ b/test/validators.js
@@ -2439,7 +2439,7 @@ describe('Validators', function () {
         new Date(0).toString(),
         new Date(Date.now() - 86400000).toString(),
       ],
-      invalid: ['2100-07-02', new Date(2017, 10, 10).toString()],
+      invalid: ['2100-07-02', new Date(2217, 10, 10).toString()],
     });
     test({
       validator: 'isBefore',


### PR DESCRIPTION
The test started failing on 2017-10-10 because the current date is after that date.