### PR TITLE
Fix for multiple consecutive dots in gmail addresses

### DIFF
--- a/lib/isEmail.js
+++ b/lib/isEmail.js
@@ -59,6 +59,9 @@ function isEmail(str, options) {
 
   var lower_domain = domain.toLowerCase();
   if (lower_domain === 'gmail.com' || lower_domain === 'googlemail.com') {
+    if (user.match(/\.{2,}/)) {
+      return false;
+    }
     user = user.replace(/\./g, '').toLowerCase();
   }
 

--- a/lib/normalizeEmail.js
+++ b/lib/normalizeEmail.js
@@ -77,7 +77,14 @@ function normalizeEmail(email, options) {
       parts[0] = parts[0].split('+')[0];
     }
     if (options.gmail_remove_dots) {
-      parts[0] = parts[0].replace(/\./g, '');
+      // this does not replace consecutive dots like example..email@gmail.com
+      var replacer = function(match, str) {
+        if (match.length > 1 ) {
+          return match;
+        }
+        return '';
+      }
+      parts[0] = parts[0].replace(/\.+/g, replacer);
     }
     if (!parts[0].length) {
       return false;

--- a/test/sanitizers.js
+++ b/test/sanitizers.js
@@ -235,8 +235,8 @@ describe('Sanitizers', function () {
         'some.name.midd.leNa.me.+extension@GoogleMail.com': 'somenamemiddlename@gmail.com',
         'some.name+extension@unknown.com': 'some.name+extension@unknown.com',
         'hans@m端ller.com': 'hans@m端ller.com',
-        'some.name.midd..leNa...me...+extension@GoogleMail.com': 'somenamemiddlename@gmail.com',
-        '"foo@bar"@baz.com': '"foo@bar"@baz.com',
+        'some.name.midd..leNa...me...+extension@GoogleMail.com': 'somenamemidd..lena...me...@gmail.com',
+        '"foo@bar"@baz.com': '"foo@bar"@baz.com'
       },
     });
 
@@ -326,6 +326,7 @@ describe('Sanitizers', function () {
       expect: {
         'SOME.name@GMAIL.com': 'somename@gmail.com',
         'SOME.name+me@GMAIL.com': 'somename@gmail.com',
+        'some.name..multiple@gmail.com': 'somename..multiple@gmail.com',
         'my.self@foo.com': 'my.self@foo.com',
       },
     });

--- a/test/sanitizers.js
+++ b/test/sanitizers.js
@@ -236,7 +236,7 @@ describe('Sanitizers', function () {
         'some.name+extension@unknown.com': 'some.name+extension@unknown.com',
         'hans@m端ller.com': 'hans@m端ller.com',
         'some.name.midd..leNa...me...+extension@GoogleMail.com': 'somenamemidd..lena...me...@gmail.com',
-        '"foo@bar"@baz.com': '"foo@bar"@baz.com'
+        '"foo@bar"@baz.com': '"foo@bar"@baz.com',
       },
     });
 

--- a/test/validators.js
+++ b/test/validators.js
@@ -84,7 +84,7 @@ describe('Validators', function () {
         'test12@invalid.co　m',
         'test13@invalid.co　m',
         'gmail...ignores...dots...@gmail.com',
-        'multiple..dots@gmail.com'
+        'multiple..dots@gmail.com',
       ],
     });
   });
@@ -163,7 +163,7 @@ describe('Validators', function () {
         'Some Name <foo@bar.co.uk.',
         'Some Name < foo@bar.co.uk >',
         'Name foo@bar.co.uk',
-        'Some Name <some..name@gmail.com>'
+        'Some Name <some..name@gmail.com>',
       ],
     });
   });

--- a/test/validators.js
+++ b/test/validators.js
@@ -54,7 +54,6 @@ describe('Validators', function () {
         'test|123@m端ller.com',
         'test+ext@gmail.com',
         'some.name.midd.leNa.me.+extension@GoogleMail.com',
-        'gmail...ignores...dots...@gmail.com',
         '"foobar"@example.com',
         '"  foo  m端ller "@example.com',
         '"foo\\@bar"@example.com',
@@ -84,6 +83,8 @@ describe('Validators', function () {
         'test11@invalid.co m',
         'test12@invalid.co　m',
         'test13@invalid.co　m',
+        'gmail...ignores...dots...@gmail.com',
+        'multiple..dots@gmail.com'
       ],
     });
   });
@@ -162,6 +163,7 @@ describe('Validators', function () {
         'Some Name <foo@bar.co.uk.',
         'Some Name < foo@bar.co.uk >',
         'Name foo@bar.co.uk',
+        'Some Name <some..name@gmail.com>'
       ],
     });
   });


### PR DESCRIPTION
Fixes #818

While single dots in email addresses are ignored by Google, multiple consecutive dots are not, and in fact sending to an email with multiple dots inserted will result in a bounce.

Here is a speculative fix for that issue, with tests. It has one specific behavior that might be contentious, but I think may be the best balance:
1. On email normalization, it does NOT replace multiple consecutive dots, only single dots, regardless of the replace_dots option.