### PR TITLE
Updated isJWT so it's conforming to specs

### DIFF
--- a/src/lib/isJWT.js
+++ b/src/lib/isJWT.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-const jwt = /^[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+$/;
+const jwt = /^([A-Za-z0-9\-_~+\/]+[=]{0,2})\.([A-Za-z0-9\-_~+\/]+[=]{0,2})(?:\.([A-Za-z0-9\-_~+\/]+[=]{0,2}))?$/;
 
 export default function isJWT(str) {
   assertString(str);

--- a/test/validators.js
+++ b/test/validators.js
@@ -2510,10 +2510,10 @@ describe('Validators', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb3JlbSI6Imlwc3VtIn0.ymiJSsMJXR6tMSr8G9usjQ15_8hKPDv_CArLhxw28MI',
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2xvciI6InNpdCIsImFtZXQiOlsibG9yZW0iLCJpcHN1bSJdfQ.rRpe04zbWbbJjwM43VnHzAboDzszJtGrNsUxaqQ-GQ8',
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqb2huIjp7ImFnZSI6MjUsImhlaWdodCI6MTg1fSwiamFrZSI6eyJhZ2UiOjMwLCJoZWlnaHQiOjI3MH19.YRLPARDmhGMC3BBk_OhtwwK21PIkVCqQe8ncIRPKo-E',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', // No signature
       ],
       invalid: [
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqb2huIjp7ImFnZSI6MjUsImhlaWdodCI6MTg1fSw',
         '$Zs.ewu.su84',
         'ks64$S/9.dy$§kz.3sd73b',
       ],


### PR DESCRIPTION
Updated the regular expression for isJWT so it's conforming to the specs.

#609 contained a regular expression where the signature part was required. However, RFC 7519 states:

>    To support use cases in which the JWT content is secured by a means
>    other than a signature and/or encryption contained within the JWT
>    (such as a signature on a data structure containing the JWT), JWTs
>    MAY also be created without a signature or encryption.  An Unsecured
>    JWT is a JWS using the "alg" Header Parameter value "none" and with
>    the empty string for its JWS Signature value, as defined in the JWA
>    specification [JWA]; it is an Unsecured JWS with the JWT Claims Set
>    as its JWS Payload.

Note that the code in the PR doesn't check if "alg" is actually "none" when the signature is missing, as it doesn't decode the JWT... I'm happy to implement that if you think I should, however.

I have also added some stricter checks to ensure that the base64 tokens are valid.