### PR TITLE
Upgrade to babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "@babel/preset-env"
+  ],
+  "plugins": [
+    "add-module-exports"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "@babel/preset-env"
+    ["@babel/preset-env", {"targets": {"node": "0.10"}}]
   ],
   "plugins": [
     "add-module-exports"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "airbnb-base",
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/build-browser.js
+++ b/build-browser.js
@@ -1,13 +1,15 @@
-const pkg = require('./package.json');
-const fs = require('fs');
-const rollup = require('rollup').rollup;
-const babel = require('rollup-plugin-babel');
+/* eslint import/no-extraneous-dependencies: 0 */
+import fs from 'fs';
+import { rollup } from 'rollup';
+import babel from 'rollup-plugin-babel';
+import babelPresetEnv from '@babel/preset-env';
+import pkg from './package.json';
 
 rollup({
   entry: 'src/index.js',
   plugins: [
     babel({
-      presets: ['es2015-rollup'],
+      presets: [[babelPresetEnv, { modules: false }]],
       babelrc: false,
     }),
   ],
@@ -17,12 +19,16 @@ rollup({
     format: 'umd',
     moduleName: pkg.name,
     banner: (
-      '/*!\n' +
-      String(fs.readFileSync('./LICENSE')).trim().split('\n').map(l => ` * ${l}`).join('\n') +
-      '\n */'
+      `/*!\n${
+        String(fs.readFileSync('./LICENSE'))
+          .trim()
+          .split('\n')
+          .map(l => ` * ${l}`)
+          .join('\n')
+      }\n */`
     ),
   })
-)).catch(e => {
-  process.stderr.write(e.message + '\n');
+)).catch((e) => {
+  process.stderr.write(`${e.message}\n`);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/core": "^7.0.0",
     "@babel/node": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "babel-eslint": "^10.0.1",
     "babel-plugin-add-module-exports": "^1.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -37,16 +37,17 @@
     "url": "https://github.com/chriso/validator.js.git"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-es2015-rollup": "^3.0.0",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/node": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-plugin-add-module-exports": "^1.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.11.0",
     "mocha": "^5.1.1",
     "rollup": "^0.43.0",
-    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-babel": "^4.0.1",
     "uglify-js": "^3.0.19"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "@babel/node": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "babel-eslint": "^10.0.1",
     "babel-plugin-add-module-exports": "^1.0.0",
     "eslint": "^4.19.1",
@@ -58,11 +58,11 @@
     "clean:browser": "rm -rf validator*.js",
     "clean": "npm run clean:node && npm run clean:browser",
     "minify": "uglifyjs validator.js -o validator.min.js  --compress --mangle --comments /Copyright/",
-    "build:browser": "babel-node build-browser && npm run minify",
+    "build:browser": "node --require @babel/register build-browser && npm run minify",
     "build:node": "babel src -d .",
     "build": "npm run build:browser && npm run build:node",
     "pretest": "npm run lint && npm run build",
-    "test": "mocha --reporter dot"
+    "test": "mocha --require @babel/register --reporter dot"
   },
   "engines": {
     "node": ">= 0.10"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "clean": "npm run clean:node && npm run clean:browser",
     "minify": "uglifyjs validator.js -o validator.min.js  --compress --mangle --comments /Copyright/",
     "build:browser": "babel-node build-browser && npm run minify",
-    "build:node": "babel src -d . --presets es2015 --plugins add-module-exports",
+    "build:node": "babel src -d .",
     "build": "npm run build:browser && npm run build:node",
     "pretest": "npm run lint && npm run build",
     "test": "mocha --reporter dot"

--- a/test/client-side.js
+++ b/test/client-side.js
@@ -1,6 +1,6 @@
-let assert = require('assert');
-let validator = require('../validator');
-let min = require('../validator.min');
+import assert from 'assert';
+import validator from '../validator';
+import min from '../validator.min';
 
 describe('Minified version', () => {
   it('should export the same things as the server-side version', () => {

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,10 +1,10 @@
-let assert = require('assert');
-let validator = require('../index');
-let isPostalCodeLocales = require('../lib/isPostalCode').locales;
-const isAlphaLocales = require('../lib/isAlpha').locales;
-const isAlphanumericLocales = require('../lib/isAlphanumeric').locales;
-const isMobilePhoneLocales = require('../lib/isMobilePhone').locales;
-const isFloatLocales = require('../lib/isFloat').locales;
+import assert from 'assert';
+import validator from '../index';
+import { locales as isPostalCodeLocales } from '../lib/isPostalCode';
+import { locales as isAlphaLocales } from '../lib/isAlpha';
+import { locales as isAlphanumericLocales } from '../lib/isAlphanumeric';
+import { locales as isMobilePhoneLocales } from '../lib/isMobilePhone';
+import { locales as isFloatLocales } from '../lib/isFloat';
 
 describe('Exports', () => {
   it('should export validators', () => {

--- a/test/sanitizers.js
+++ b/test/sanitizers.js
@@ -1,5 +1,5 @@
-let validator = require('../index');
-let format = require('util').format;
+import { format } from 'util';
+import validator from '../index';
 
 function test(options) {
   let args = options.args || [];

--- a/test/validators.js
+++ b/test/validators.js
@@ -1,11 +1,10 @@
-let validator = require('../index'),
-  format = require('util').format,
-  assert = require('assert'),
-  path = require('path'),
-  fs = require('fs'),
-  vm = require('vm');
+import { format } from 'util';
+import assert from 'assert';
+import fs from 'fs';
+import vm from 'vm';
+import validator from '../index';
 
-let validator_js = fs.readFileSync(path.join(__dirname, '../validator.js')).toString();
+let validator_js = fs.readFileSync(require.resolve('../validator.js')).toString();
 
 function test(options) {
   let args = options.args || [];


### PR DESCRIPTION
- Update `babel` dependencies
- Use `.babelrc` instead of passing `presets` and `plugins` via CLI
- Fix linting errors on `build-browser` script
- Use `babel-eslint` parser for `eslint`
- Use `@babel/register` instead of `@babel/node`, use `babel` when running all tests

Should remove `babel-plugin-add-module-exports` later on.