### PR TITLE
Fix bad newlines.

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -1903,9 +1903,10 @@ var default_normalize_email_options = {
   icloud_lowercase: true,
   // Removes the subaddress (e.g. "+foo") from the email address
   icloud_remove_subaddress: true
-}; // List of domains used by iCloud
-
-var icloud_domains = ['icloud.com', 'me.com']; // List of domains used by Outlook.com and its predecessors
+};
+// List of domains used by iCloud
+var icloud_domains = ['icloud.com', 'me.com'];
+// List of domains used by Outlook.com and its predecessors
 // This list is likely incomplete.
 // Partial reference:
 // https://blogs.office.com/2013/04/17/outlook-com-gets-two-step-verification-sign-in-by-alias-and-new-international-domains/

--- a/validator.js
+++ b/validator.js
@@ -1931,8 +1931,9 @@ function normalizeEmail(email, options) {
   var raw_parts = email.split('@');
   var domain = raw_parts.pop();
   var user = raw_parts.join('@');
-  var parts = [user, domain]; // The domain is always lowercased, as it's case-insensitive per RFC 1035
+  var parts = [user, domain];
 
+  // The domain is always lowercased, as it's case-insensitive per RFC 1035
   parts[1] = parts[1].toLowerCase();
 
   if (parts[1] === 'gmail.com' || parts[1] === 'googlemail.com') {


### PR DESCRIPTION
Comments are unrelated to lines they're attached to. No functional change, just moving linebreaks to make sense.

Note that I think the icloud_domains is probably missing mac.com (which predates MobileMe), but I thought that might involve a greater discussion than just fixing the line endings.