### PR TITLE
Converted toDate to handle more formats

### DIFF
--- a/lib/toDate.js
+++ b/lib/toDate.js
@@ -5,15 +5,36 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = toDate;
 
-var _assertString = _interopRequireDefault(require("./util/assertString"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _asserts = require("./util/asserts");
 
 function toDate(date) {
-  (0, _assertString.default)(date);
-  date = Date.parse(date);
+  (0, _asserts.assertStringOrNumber)(date);
+
+  if (!date) {
+    return date;
+  }
+
+  if (typeof date === 'number') {
+    date = String(date);
+  }
+
+  if (typeof date === 'string' && /^\d+$/.test(date)) {
+    if (date.length === 10) {
+      date += '000';
+    }
+
+    date = new Date(Number(date));
+  } else {
+    date = Date.parse(date);
+  }
+
   return !isNaN(date) ? new Date(date) : null;
 }
 
+console.log(toDate('04 Dec 1995 00:12:00 GMT'));
+console.log(toDate('1549012444'));
+console.log(toDate('1549012444000'));
+console.log(toDate(1549012444));
+console.log(toDate(1549012444000));
 module.exports = exports.default;
 module.exports.default = exports.default;

--- a/lib/toDate.js
+++ b/lib/toDate.js
@@ -31,10 +31,5 @@ function toDate(date) {
   return !isNaN(date) ? new Date(date) : null;
 }
 
-console.log(toDate('04 Dec 1995 00:12:00 GMT'));
-console.log(toDate('1549012444'));
-console.log(toDate('1549012444000'));
-console.log(toDate(1549012444));
-console.log(toDate(1549012444000));
 module.exports = exports.default;
 module.exports.default = exports.default;

--- a/lib/util/asserts.js
+++ b/lib/util/asserts.js
@@ -1,0 +1,34 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.assertStringOrNumber = assertStringOrNumber;
+exports.default = void 0;
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function assertStringOrNumber(input) {
+  var isStringOrNumber = typeof input === 'string' || input instanceof String || typeof input === 'number' || input instanceof Number;
+
+  if (!isStringOrNumber) {
+    var invalidType;
+
+    if (input === null) {
+      invalidType = 'null';
+    } else {
+      invalidType = _typeof(input);
+
+      if (invalidType === 'object' && input.constructor && input.constructor.hasOwnProperty('name')) {
+        invalidType = input.constructor.name;
+      } else {
+        invalidType = "a ".concat(invalidType);
+      }
+    }
+
+    throw new TypeError("Expected string/number but received ".concat(invalidType, "."));
+  }
+}
+
+var _default = assertStringOrNumber;
+exports.default = _default;

--- a/src/lib/toDate.js
+++ b/src/lib/toDate.js
@@ -1,7 +1,20 @@
-import assertString from './util/assertString';
+import { assertStringOrNumber } from './util/asserts';
 
 export default function toDate(date) {
-  assertString(date);
-  date = Date.parse(date);
+  assertStringOrNumber(date);
+  if (!date) {
+    return date;
+  }
+  if (typeof date === 'number') {
+    date = String(date);
+  }
+  if (typeof date === 'string' && (/^\d+$/).test(date)) {
+    if (date.length === 10) {
+      date += '000';
+    }
+    date = new Date(Number(date));
+  } else {
+    date = Date.parse(date);
+  }
   return !isNaN(date) ? new Date(date) : null;
 }

--- a/src/lib/util/asserts.js
+++ b/src/lib/util/asserts.js
@@ -1,0 +1,23 @@
+export function assertStringOrNumber(input) {
+  const isStringOrNumber = (
+    (typeof input === 'string' || input instanceof String)
+    || (typeof input === 'number' || input instanceof Number)
+  );
+
+  if (!isStringOrNumber) {
+    let invalidType;
+    if (input === null) {
+      invalidType = 'null';
+    } else {
+      invalidType = typeof input;
+      if (invalidType === 'object' && input.constructor && input.constructor.hasOwnProperty('name')) {
+        invalidType = input.constructor.name;
+      } else {
+        invalidType = `a ${invalidType}`;
+      }
+    }
+    throw new TypeError(`Expected string/number but received ${invalidType}.`);
+  }
+}
+
+export default assertStringOrNumber;


### PR DESCRIPTION
toDate can now convert more formats to `Date`.

Eg: "1549012444478", 1549012444478, 1549012444, "1549012444"